### PR TITLE
Add "Gaming" to Retro-Go menu item

### DIFF
--- a/components/fri3d_firmware/src/main.cpp
+++ b/components/fri3d_firmware/src/main.cpp
@@ -23,7 +23,7 @@ void app_main(void)
     auto &appManager = application.getAppManager();
 
     CPartitionBoot micropython("Hardware test", "micropython");
-    CPartitionBoot retroGo("Retro Go", "launcher");
+    CPartitionBoot retroGo("Retro-Go Gaming", "launcher");
 
     // (for now) the order in which you register determines the display order in the launcher
     appManager.registerApp(Launcher::launcher);


### PR DESCRIPTION
As many kids (and adults) don't know what Retro-Go is, I thought it good to add "Gaming" to the menu entry so that it's more clear what it is.

First I considered "Retro-Go Games" but the games themselves are not actually built by Retro-Go. It's the "Retro Gaming" *experience* that is provided by Retro-Go. That's why I went with "Retro-Go Gaming" in the end.